### PR TITLE
Add catch-all VPN On Demand Rule

### DIFF
--- a/roles/vpn/templates/mobileconfig.j2
+++ b/roles/vpn/templates/mobileconfig.j2
@@ -52,6 +52,10 @@
                     <key>URLStringProbe</key>
                       <string>http://captive.apple.com/hotspot-detect.html</string>
                   </dict>
+                  <dict>
+                    <key>Action</key>
+                      <string>Disconnect</string>
+                  </dict>
                 </array>
 {% else %}
 {% endif %}


### PR DESCRIPTION
If a user is not connected to a trusted Wi-Fi network or if the
URLStringProbe fails none of the existing dictionaries match.

According to the Apple Configuration Profile Reference[1] section "VPN
Payload > On Demand Rules Dictionary Keys" a default behavior for
unknown networks with no matching criteria should always be set as the
last dictionary in the array. The current default behavior is to allow a
connection to occur, but this behavior is not guaranteed.

Tear down the VPN connection and do not reconnect on demand as long as
the catch-all dictionary matches to guarantee the default behavior and
more specifically allow users to access captive portals.

[1]: https://developer.apple.com/library/content/featuredarticles/iPhoneConfigurationProfileRef/Introduction/Introduction.html

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [] I have read the **CONTRIBUTING** document.
- [] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.
